### PR TITLE
Add simple Dockerfile for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM clojure:temurin-17-bullseye-slim
+
+EXPOSE 4444
+EXPOSE 4440
+EXPOSE 4911
+
+WORKDIR /site
+
+COPY . .
+
+ENV SITE_HOME=/site
+ENV PATH="$SITE_HOME/bin:$SITE_HOME/server/bin:${PATH}"
+
+COPY --from=ghcr.io/babashka/babashka:latest /usr/local/bin/bb /usr/bin/bb
+COPY --from=ghcr.io/charmbracelet/gum:latest /usr/local/bin/gum /usr/bin/gum
+
+RUN \
+apt update && \
+apt install -y jo && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $HOME/.config/site && \
+cp $SITE_HOME/server/etc/config/local-development.edn ~/.config/site/config.edn
+
+HEALTHCHECK --interval=5m --timeout=3s \
+CMD site ping || exit 1
+
+ENTRYPOINT ["site-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+## -*- dockerfile-image-name: "site-server" -*-
 FROM clojure:temurin-17-bullseye-slim
 
 EXPOSE 4444
@@ -11,6 +12,9 @@ COPY . .
 
 ENV SITE_HOME=/site
 ENV PATH="$SITE_HOME/bin:$SITE_HOME/server/bin:${PATH}"
+
+# Make sure gum has color
+ENV CLICOLOR_FORCE=true
 
 COPY --from=ghcr.io/babashka/babashka:latest /usr/local/bin/bb /usr/bin/bb
 COPY --from=ghcr.io/charmbracelet/gum:latest /usr/local/bin/gum /usr/bin/gum

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM clojure:temurin-17-bullseye-slim
 EXPOSE 4444
 EXPOSE 4440
 EXPOSE 4911
+EXPOSE 9091
 
 WORKDIR /site
 
@@ -24,4 +25,5 @@ cp $SITE_HOME/server/etc/config/local-development.edn ~/.config/site/config.edn
 HEALTHCHECK --interval=5m --timeout=3s \
 CMD site ping || exit 1
 
-ENTRYPOINT ["site-server"]
+WORKDIR /site/server
+ENTRYPOINT ["clj", "-M:dev"]

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -98,6 +98,8 @@
                "--middleware" "[cider.nrepl/cider-middleware]"]
    :jvm-opts
    ["-XX:-OmitStackTraceInFastThrow"
+    "-Dlogback.configurationFile=dev/logback.xml"
+    "-Ddev"
     "-Dclojure.spec.check-asserts=true"]}
 
   :test

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -81,8 +81,7 @@
   ;; Used by /_site/users (401 handler), at least
   hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
 
-  clj-commons/clj-yaml {:mvn/version "1.0.26"}
-  }
+  clj-commons/clj-yaml {:mvn/version "1.0.26"}}
 
  :aliases
  {:dev
@@ -92,13 +91,14 @@
     djblue/portal {:mvn/version "0.29.1"}
     borkdude/rewrite-edn {:mvn/version "0.4.6"}
     juxt.site/installer-graph {:local/root "../installer-graph"}
-    ;;lambdaisland/kaocha {:mvn/version "1.0.887"}
-    }
+    cider/cider-nrepl {:mvn/version "0.37.0"}
+    nrepl/nrepl {:mvn/version "1.0.0"}}
+   :main-opts ["-m" "nrepl.cmdline"
+               "-p" "9091"
+               "--middleware" "[cider.nrepl/cider-middleware]"]
    :jvm-opts
    ["-XX:-OmitStackTraceInFastThrow"
-    "-Dclojure.server.site={:port,50505,:accept,juxt.site.repl-server/repl}"
-    "-Dclojure.spec.check-asserts=true"
-    "--add-opens" "java.base/java.util.concurrent=ALL-UNNAMED"]}
+    "-Dclojure.spec.check-asserts=true"]}
 
   :test
   {:extra-paths ["test"]

--- a/server/dev/user.clj
+++ b/server/dev/user.clj
@@ -51,7 +51,7 @@
   (println "Site by JUXT. Copyright (c) 2020-2023, JUXT LTD.")
   (println "Compiling code, please wait...")
   (log/info "Starting development system")
-  (alter-var-root #'main/profile (constantly :dev))
+  ;; (alter-var-root #'main/profile (constantly :dev))
   (let [system-config (main/system-config)
         system (ig/init system-config)]
     (alter-var-root #'main/*system* (constantly system)))

--- a/server/dev/user.clj
+++ b/server/dev/user.clj
@@ -75,3 +75,6 @@
   (println (ansi/yellow "Enter (help) for help"))
 
   :ready)
+
+(when (System/getProperty "dev")
+  (start))


### PR DESCRIPTION
This may supercede `server/Dockerfile` now, if that's the case I can
rebase this to also remove that

NOTE that a container has to be run with `--net host` so that `localhost` resolves correctly. If this will replace `server/Dockerfile` I'll add README notes too