### PR TITLE
this commit fixes #9

### DIFF
--- a/site-cli.edn
+++ b/site-cli.edn
@@ -15,7 +15,8 @@
   ;; Override bb's help
   help
   {:doc "Show help"
-   :task (juxt.site.bb.tasks/help-task)}
+   :task (juxt.site.bb.tasks/help-task)
+   :override-builtin true}
 
   post-init
   {:doc "Show post-init options. Requires the server."


### PR DESCRIPTION
Added `:override-builtin true` to the `help` task in `site-cli.edn`, per the `Conflicting file / task / subcommand names` section of  https://book.babashka.org, to eliminate the `babashka` warnings when executing the `site` command.