### PR TITLE
Add a simple bootstrap task

### DIFF
--- a/site-cli.edn
+++ b/site-cli.edn
@@ -46,6 +46,10 @@
         :task (juxt.site.bb.tasks/init
                (juxt.site.bb.tasks/parse-opts))}
 
+  bootstrap {:doc "Bootstrap an instance with a default user & a demo API."
+             :task (juxt.site.bb.tasks/bootstrap
+                    (juxt.site.bb.tasks/parse-opts))}
+
   list
   {:doc "List resources. Only available via localhost."
    :opts {:args->opts [:pattern]}

--- a/src/juxt/site/bb/tasks.clj
+++ b/src/juxt/site/bb/tasks.clj
@@ -1046,3 +1046,35 @@
      (format
       "Now browse to https://petstore.swagger.io/?url=%s/petstore/openapi.json"
       data-base-uri))))
+
+(defn bootstrap [opts]
+  (let [cfg (config opts)
+        admin-base-uri (get cfg "admin-base-uri")
+        client-id "site-cli"
+        token (atom nil)]
+    (init opts true)
+    ;; Flush the output
+    (println)
+    (reset! token
+            (request-token
+             {:client-id client-id
+              :client-secret
+              (request-client-secret admin-base-uri client-id)}))
+    (register-admin-user opts)
+    (println "A user with 'site-admin' with password 'site-admin' has been created.")
+    (install-bundles
+     (assoc
+      opts
+      :resources-uri
+      (str admin-base-uri "/resources")
+      :bundles
+      [["juxt/site/system-api-openapi"]
+       ["juxt/site/oauth-authorization-endpoint" {"session-scope" "https://auth.example.org/session-scopes/form-login-session"}]
+       ["juxt/site/login-form"]
+       ["juxt/site/system-client" {"client-id" "swagger-ui"}]]))
+    (println "\n\n")
+    (println "Next steps: ")
+    (println "\tBrowse to https://petstore.swagger.io/?url=http://localhost:4444/_site/openapi.json")
+    (println "\tClick on authorize, add swagger-ui as the client_id, select all scopes and authorize.")
+    ;; TODO As more demos are added, adjust this to be a gum selector
+    (install-petstore opts)))

--- a/src/juxt/site/bb/tasks.clj
+++ b/src/juxt/site/bb/tasks.clj
@@ -975,18 +975,15 @@
 ;; Temporary convenience for ongoing development
 
 (defn register-admin-user [opts]
-  (let [password "foobar"]
-    (register-user
-     (merge {:username "mal"
-             :password password
-             :fullname "Malcolm Sparks"} opts))
-    (assign-user-role
-     (merge {:username "mal"
-             :role "SiteAdmin"} opts))
-    (if-let [token (request-token
-                    (merge {:username "mal"
-                            :password password
-                            :client-id "site-cli"} opts))]
+  (let [password "site-admin"
+        opts (merge {:username "site-admin"
+                     :password password
+                     :role "SiteAdmin"
+                     :client-id "site-cli"
+                     :fullname "Site Admin"} opts)]
+    (register-user opts)
+    (assign-user-role opts)
+    (if-let [token (request-token opts)]
       (save-access-token token)
       (throw (ex-info "Failed to get token" {})))))
 


### PR DESCRIPTION
When the book is amended to handle this, I'll also add the following note; that `.curlrc` has to be cleared out beforehand.

If desired, I can make another PR to handle the token data outside of that before this gets merged to make increase ease-of-use.