### PR TITLE
Add option to provide client-secret to the site init function

### DIFF
--- a/installers/auth.example.org/applications/insite.edn
+++ b/installers/auth.example.org/applications/insite.edn
@@ -6,6 +6,7 @@
   :juxt.site/operation-uri "https://auth.example.org/operations/oauth/register-application"
   :juxt.site/input
   {:juxt.site/client-id "insite"
+   :juxt.site/client-secret ^:optional {:value "{{client-secret}}"}
    :juxt.site/client-type "confidential"
    :juxt.site/supported-grant-types ["authorization_code"]
    :juxt.site/authorization-server "https://auth.example.org"

--- a/installers/auth.example.org/applications/site-cli.edn
+++ b/installers/auth.example.org/applications/site-cli.edn
@@ -6,6 +6,7 @@
   :juxt.site/operation-uri "https://auth.example.org/operations/oauth/register-application"
   :juxt.site/input
   {:juxt.site/client-id "site-cli"
+   :juxt.site/client-secret ^:optional {:value "{{client-secret}}"}
    :juxt.site/client-type "confidential"
 ;;   :juxt.site/supported-grant-types ["password"]
    :juxt.site/authorization-server "https://auth.example.org"

--- a/installers/bundles.edn
+++ b/installers/bundles.edn
@@ -726,7 +726,8 @@
  "juxt/site/system-client"
  {:juxt.site/title "System client"
   :juxt.site/description "Register a client with the SiteBootstrap and SiteSystemQuery roles. System clients are able to authenticate themselves with the client_credentials grant."
-  :juxt.site/parameters [["client-id" {}]]
+  :juxt.site/parameters [["client-id" {}]
+                         ["client-secret" {:optional true}]]
   :juxt.site/installers
   [{:juxt.site/base-uri "https://auth.example.org"
     :juxt.site/installer-path "/applications/{{client-id}}"

--- a/server/test/juxt/site/install/common_install_util_test.clj
+++ b/server/test/juxt/site/install/common_install_util_test.clj
@@ -1,0 +1,93 @@
+(ns juxt.site.install.common-install-util-test
+  (:require [juxt.site.install.common-install-util :as sut]
+            [clojure.test :refer [deftest testing is]:as t]))
+
+(deftest render-form-templates-simple-test
+  (testing "Tests that render-form-templates returns an empty map if an empty map provided as form"
+    (sut/render-form-templates {} {}))
+
+  (testing "Tests that the render-form-templates returns input if no selmer templates in the input"
+    (let [input {:hello "World"}]
+      (is (= input (sut/render-form-templates input {}))))
+
+    (let [input {:hello {:deeper "World"}}]
+      (is (= input (sut/render-form-templates input {}))))
+
+    (let [input {:hello {:deeper "World"}
+                 :goodbye "multiple"}]
+      (is (= input (sut/render-form-templates input {}))))
+
+    (let [input {:hello {:deeper "World"}
+                 :goodbye "multiple"}]
+      (is (= input (sut/render-form-templates input {"extra" "input"}))))))
+
+(deftest render-form-templates-replacement-test
+  (testing "Tests that the render-form-templates returns modified if selmer templates in the input"
+    (is (= {:hello "Land"}
+           (sut/render-form-templates {:hello "{{World}}"}
+                                      {"World" "Land"})))
+
+    (is (= {:hello {:deeper "Land"}}
+           (sut/render-form-templates {:hello {:deeper "{{World}}"}}
+                                      {"World" "Land"})))
+
+    (is (= {:hello {:deeper "Land"}
+            :goodbye "Planet"}
+           (sut/render-form-templates {:hello {:deeper "{{World}}"}
+                                       :goodbye "{{multiple}}"}
+                                      {"World" "Land"
+                                       "multiple" "Planet"})))
+    (is (= {:hello "Land"}
+           (sut/render-form-templates {:hello "{{World}}"}
+                                      {"World" "Land"
+                                       "extra" "input"})))))
+
+(deftest render-form-templates-selmer-syntax-test
+  (testing "Tests that the render-form-templates supports the selmer syntax"
+    (is (= {:hello "LAND"
+            :goodbye "planet"}
+           (sut/render-form-templates {:hello "{{World|upper}}"
+                                       :goodbye "{{multiple|lower}}"}
+                                      {"World" "Land"
+                                       "multiple" "Planet"})))))
+
+(deftest render-form-templates-missing-replacement-test
+  (testing "Tests that the render-form-templates throws exception if the required template parameter is missing"
+    (is (thrown? Exception
+                 (sut/render-form-templates {:hello "{{World}}"}
+                                            nil)))
+
+    (is (thrown? Exception
+                 (sut/render-form-templates {:hello "{{World}}"}
+                                            {})))
+
+    (is (thrown? Exception
+                 (sut/render-form-templates {:hello "{{World}}"}
+                                            {"multiple" "Planet"})))))
+
+(deftest render-form-templates-supports-optional-replacement-test
+  (testing "Tests that the render-form-templates replaces optional fields where the parameter is provided"
+    (is (= {:hello "Land"}
+           (sut/render-form-templates {:hello ^:optional {:value "{{World}}"}}
+                                      {"World" "Land"})))
+
+    (is (=  {}
+            (sut/render-form-templates {:hello ^:optional {:value "{{World}}"}}
+                                       {})))
+
+    (is (= {}
+           (sut/render-form-templates {:hello ^:optional {:value "{{World}}"}}
+                                      {"multiple" "Planet"}))))
+
+  (testing "Tests that the render-form-templates skips optional fields where the parameter is not provided."
+    (is (= {}
+           (sut/render-form-templates {:hello ^:optional {:value "{{World}}"}}
+                                      nil)))
+
+    (is (=  {}
+            (sut/render-form-templates {:hello ^:optional {:value "{{World}}"}}
+                                       {})))
+
+    (is (= {}
+           (sut/render-form-templates {:hello ^:optional {:value "{{World}}"}}
+                                      {"multiple" "Planet"})))))

--- a/server/tests.edn
+++ b/server/tests.edn
@@ -1,32 +1,33 @@
 #kaocha/v1
- {:plugins [;;:kaocha.plugin.alpha/info
+{:plugins [;;:kaocha.plugin.alpha/info
            ;;:kaocha.plugin/cloverage
-            ]
+           ]
 
-  :tests [{:id :test
-           :test-paths ["test"]
-           :ns-patterns
-           ["juxt.site.cors-test"
-            "juxt.site.return-test"
-            "juxt.site.tx-test"
-            "juxt.site.events-test"
-            "juxt.site.graphql-compiler-test"
-            "juxt.site.form-based-auth-test"
-            "juxt.site.bundles-test"
-            "juxt.site.eql-datalog-compiler-test"
-            "juxt.site.oauth-test"
-            "juxt.site.oauth-grants-test"
-            "juxt.site.openid-test"
-            "juxt.site.system-api-test"
-            "juxt.site.whoami-test"
-            "juxt.site.schema-test"
-            "juxt.site.basic-auth-test"
-            "juxt.site.create-users-test"
-            "juxt.site.post-openapi-test"
-            "juxt.site.error-test"
-            "juxt.site.installer-test"
-            "juxt.site.petstore-test"
-            "juxt.site.order-test"
-            "juxt.site.application-registration-test"]}]
+ :tests [{:id :test
+          :test-paths ["test"]
+          :ns-patterns
+          ["juxt.site.cors-test"
+           "juxt.site.return-test"
+           "juxt.site.tx-test"
+           "juxt.site.events-test"
+           "juxt.site.graphql-compiler-test"
+           "juxt.site.form-based-auth-test"
+           "juxt.site.bundles-test"
+           "juxt.site.eql-datalog-compiler-test"
+           "juxt.site.oauth-test"
+           "juxt.site.oauth-grants-test"
+           "juxt.site.openid-test"
+           "juxt.site.system-api-test"
+           "juxt.site.whoami-test"
+           "juxt.site.schema-test"
+           "juxt.site.basic-auth-test"
+           "juxt.site.create-users-test"
+           "juxt.site.post-openapi-test"
+           "juxt.site.error-test"
+           "juxt.site.installer-test"
+           "juxt.site.petstore-test"
+           "juxt.site.order-test"
+           "juxt.site.application-registration-test"
+           "juxt.site.install.common-install-util-test"]}]
 
-  :reporter kaocha.report/documentation}
+ :reporter kaocha.report/documentation}

--- a/src/juxt/site/bb/tasks.clj
+++ b/src/juxt/site/bb/tasks.clj
@@ -786,8 +786,14 @@
            ;; RFC 7662 token introspection
            ["juxt/site/oauth-introspection-endpoint" {}]
            ;; Register the clients
-           ["juxt/site/system-client" {"client-id" "site-cli"}]
-           ["juxt/site/system-client" {"client-id" "insite"}]]))
+           ["juxt/site/system-client" (let [site-cli-config {"client-id" "site-cli"}]
+                                        (if-let [site-cli-secret (:site-cli-secret opts)]
+                                          (assoc site-cli-config "client-secret" site-cli-secret)
+                                          site-cli-config))]
+           ["juxt/site/system-client" (let [insite-config {"client-id" "insite"}]
+                                        (if-let [insite-secret (:insite-secret opts)]
+                                          (assoc insite-config "client-secret" insite-secret)
+                                          insite-config))]]))
 
         ;; Delete any stale client-secret files
         (doseq [client-id ["site-cli" "insite"]

--- a/src/juxt/site/bb/tasks.clj
+++ b/src/juxt/site/bb/tasks.clj
@@ -800,9 +800,17 @@
             ;; RFC 7662 token introspection
             ["juxt/site/oauth-introspection-endpoint" {}]
             ;; Register the clients
-            ["juxt/site/system-client" {"client-id" "site-cli"}]
-            ["juxt/site/system-client" {"client-id" "insite"}]]))
-
+            ["juxt/site/system-client"
+             (let [site-cli-config {"client-id" "site-cli"}]
+               (if-let [site-cli-secret (:site-cli-secret opts)]
+                 (assoc site-cli-config "client-secret" site-cli-secret)
+                 site-cli-config))]
+            ["juxt/site/system-client"
+             (let [insite-config {"client-id" "insite"}]
+               (if-let [insite-secret (:insite-secret opts)]
+                 (assoc insite-config "client-secret" insite-secret)
+                 insite-config))]])
+          )
          ;; Delete any stale client-secret files
          (doseq [client-id ["site-cli" "insite"]
                  :let [secret-file (client-secret-file opts client-id)]]


### PR DESCRIPTION
Add the option to provide the client-secrets on the CLI with the `--site-cli-client-secret` and `--insite-client-secret` options. This is required for providing the secret via other tools such as AWS Secrets Manager.

This also adds the ability to have optional fields in the selmer templating via a `:optional` metadata tag.

Also adds the ability for optional parameters to a bundle, which will allow the values to be nil, without prompting the user to provide the values on the CLI. This allows for unattended install.